### PR TITLE
Will upgrade dependencies to .Net Core 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ generators/app/templates/test/StarterKit.IntegrationTests/obj/
 generators/app/templates/test/StarterKit.UnitTests/bin/
 generators/app/templates/test/StarterKit.UnitTests/obj/
 
+/.vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # generator-dgp-web-aspnetcore
 
+## 4.0.0
+ - update to .Net Core 2.0 dependencies
+
 ## 3.0.2
 
 - update version xunit packages and dotnet-xunit CLI tool added to integration test project.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # generator-dgp-web-aspnetcore
 
-Yeoman generator for a new ASP.NET Core 1.1 Web Client project.
+Yeoman generator for a new ASP.NET Core 2.0 Web Client project.
 
 ## Installation
 

--- a/generators/app/templates/src/StarterKit/StarterKit.csproj
+++ b/generators/app/templates/src/StarterKit/StarterKit.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0-BUILDNUMBER</VersionPrefix>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>StarterKit</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>StarterKit</PackageId>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dotnet5.6;portable-net45+win8+wp8+wpa81</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,21 +20,22 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <PackageReference Include="Digipolis.ApplicationServices" Version="2.0.0" />
     <PackageReference Include="Digipolis.Common" Version="3.0.0" />
     <PackageReference Include="Digipolis.Correlation" Version="3.0.0" />
@@ -47,8 +48,8 @@
     <PackageReference Include="Digipolis.Serilog.Message" Version="2.0.0" />
     <PackageReference Include="Digipolis.ServiceAgents" Version="5.0.0" />
     <PackageReference Include="Digipolis.Web" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="5.2.0-unstable0004" />
     <PackageReference Include="Swashbuckle" Version="6.0.0-beta902" />

--- a/generators/app/templates/src/StarterKit/StarterKit.csproj
+++ b/generators/app/templates/src/StarterKit/StarterKit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0-BUILDNUMBER</VersionPrefix>
+    <VersionPrefix>1.0.0-BUILDNUMBER</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>StarterKit</AssemblyName>

--- a/generators/app/templates/src/StarterKit/StarterKit.csproj
+++ b/generators/app/templates/src/StarterKit/StarterKit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0-BUILDNUMBER</VersionPrefix>
+    <VersionPrefix>2.0.0-BUILDNUMBER</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>StarterKit</AssemblyName>
@@ -11,7 +11,11 @@
     <AssetTargetFallback>$(AssetTargetFallback);dotnet5.6;portable-net45+win8+wp8+wpa81</AssetTargetFallback>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
+    <ItemGroup>
     <Compile Remove="node_modules" />
     <None Update="_config\**\*;wwwroot\**\*;Mvc\Views\Home\Index.cshtml">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -19,8 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="AutoMapper" Version="6.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
@@ -38,10 +41,11 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <PackageReference Include="Digipolis.ApplicationServices" Version="2.0.0" />
     <PackageReference Include="Digipolis.Common" Version="3.0.0" />
-    <PackageReference Include="Digipolis.Correlation" Version="3.0.0" />
-    <PackageReference Include="Digipolis.Errors" Version="5.0.0" />
+    <PackageReference Include="Digipolis.Correlation" Version="4.0.0" />
+    <PackageReference Include="Digipolis.Errors" Version="5.1.0" />
     <PackageReference Include="Digipolis.Json" Version="3.0.0" />
-    <PackageReference Include="Digipolis.Serilog" Version="3.0.0" />
+    <PackageReference Include="Digipolis.Auth" Version="3.0.0-beta1" />
+    <PackageReference Include="Digipolis.Serilog" Version="4.0.0" />
     <PackageReference Include="Digipolis.Serilog.ApplicationServices" Version="3.0.0" />
     <PackageReference Include="Digipolis.Serilog.AuthService" Version="3.0.0" />
     <PackageReference Include="Digipolis.Serilog.Correlation" Version="3.0.0" />
@@ -51,7 +55,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="5.2.0-unstable0004" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="5.7.0" />
     <PackageReference Include="Swashbuckle" Version="6.0.0-beta902" />
   </ItemGroup>
 

--- a/generators/app/templates/test/StarterKit.IntegrationTests/StarterKit.IntegrationTests.csproj
+++ b/generators/app/templates/test/StarterKit.IntegrationTests/StarterKit.IntegrationTests.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <Description>StarterKit integration tests.</Description>
     <Authors>digipolis.be</Authors>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>StarterKit.IntegrationTests</AssemblyName>
     <PackageId>StarterKit.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3707" />
-    <PackageReference Include="xunit" Version="2.3.0-beta4-build3707" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/generators/app/templates/test/StarterKit.UnitTests/StarterKit.UnitTests.csproj
+++ b/generators/app/templates/test/StarterKit.UnitTests/StarterKit.UnitTests.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <Description>StarterKit unit tests.</Description>
     <Authors>digipolis.be</Authors>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>StarterKit.UnitTests</AssemblyName>
     <PackageId>StarterKit.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
+    
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,13 +18,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3707" />
-    <PackageReference Include="xunit" Version="2.3.0-beta4-build3707" />
-    <PackageReference Include="moq.netcore" Version="4.4.0-beta8" />
+    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-dgp-web-aspnetcore",
-  "version": "5.0.0",
+  "version": "4.0.0",
   "description": "Generator for a new ASP.NET Core 1.1 Web Client project.",
   "homepage": "",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-dgp-web-aspnetcore",
-  "version": "3.0.2",
+  "version": "5.0.0",
   "description": "Generator for a new ASP.NET Core 1.1 Web Client project.",
   "homepage": "",
   "author": {


### PR DESCRIPTION
TargetFramework is naar 2.0 omgeschakeld, alle dependencies naar de packages aangepast naar de hogere versie
Beta-builds van Xunit en Moq uit de dependencies gehaald en upgrade gegeven naar last stable version