### PR TITLE
FIX: same site cookie (chromium update)

### DIFF
--- a/generators/app/templates/src/FOOBAR/Shared/Extensions/SameSiteCookieServiceCollectionExtensions.cs
+++ b/generators/app/templates/src/FOOBAR/Shared/Extensions/SameSiteCookieServiceCollectionExtensions.cs
@@ -1,0 +1,122 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FOOBAR.Shared.Extensions
+{
+  public static class SameSiteCookiesServiceCollectionExtensions
+  {
+    /// <summary>
+    /// -1 defines the unspecified value, which tells ASPNET Core to NOT
+    /// send the SameSite attribute. With ASPNET Core 3.1 the
+    /// <seealso cref="SameSiteMode" /> enum will have a definition for
+    /// Unspecified.
+    /// </summary>
+    private const SameSiteMode Unspecified = (SameSiteMode)(-1);
+
+    /// <summary>
+    /// Configures a cookie policy to properly set the SameSite attribute
+    /// for Browsers that handle unknown values as Strict. Ensure that you
+    /// add the <seealso cref="Microsoft.AspNetCore.CookiePolicy.CookiePolicyMiddleware" />
+    /// into the pipeline before sending any cookies!
+    /// </summary>
+    /// <remarks>
+    /// Minimum ASPNET Core Version required for this code:
+    ///   - 2.1.14
+    ///   - 2.2.8
+    ///   - 3.0.1
+    ///   - 3.1.0-preview1
+    /// Starting with version 80 of Chrome (to be released in February 2020)
+    /// cookies with NO SameSite attribute are treated as SameSite=Lax.
+    /// In order to always get the cookies send they need to be set to
+    /// SameSite=None. But since the current standard only defines Lax and
+    /// Strict as valid values there are some browsers that treat invalid
+    /// values as SameSite=Strict. We therefore need to check the browser
+    /// and either send SameSite=None or prevent the sending of SameSite=None.
+    /// Relevant links:
+    /// - https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1
+    /// - https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
+    /// - https://www.chromium.org/updates/same-site
+    /// - https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    /// - https://bugs.webkit.org/show_bug.cgi?id=198181
+    /// </remarks>
+    /// <param name="services">The service collection to register <see cref="CookiePolicyOptions" /> into.</param>
+    /// <returns>The modified <see cref="IServiceCollection" />.</returns>
+    public static IServiceCollection ConfigureNonBreakingSameSiteCookies(this IServiceCollection services)
+    {
+      services.Configure<CookiePolicyOptions>(options =>
+      {
+        options.MinimumSameSitePolicy = Unspecified;
+        options.OnAppendCookie = cookieContext =>
+           CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+        options.OnDeleteCookie = cookieContext =>
+           CheckSameSite(cookieContext.Context, cookieContext.CookieOptions);
+      });
+
+      return services;
+    }
+
+    private static void CheckSameSite(HttpContext httpContext, CookieOptions options)
+    {
+      if (options.SameSite == SameSiteMode.None)
+      {
+        var userAgent = httpContext.Request.Headers["User-Agent"].ToString();
+
+        if (DisallowsSameSiteNone(userAgent))
+        {
+          options.SameSite = Unspecified;
+        }
+      }
+    }
+
+    /// <summary>
+    /// Checks if the UserAgent is known to interpret an unknown value as Strict.
+    /// For those the <see cref="CookieOptions.SameSite" /> property should be
+    /// set to <see cref="Unspecified" />.
+    /// </summary>
+    /// <remarks>
+    /// This code is taken from Microsoft:
+    /// https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    /// </remarks>
+    /// <param name="userAgent">The user agent string to check.</param>
+    /// <returns>Whether the specified user agent (browser) accepts SameSite=None or not.</returns>
+    private static bool DisallowsSameSiteNone(string userAgent)
+    {
+      // Cover all iOS based browsers here. This includes:
+      //   - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      //   - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      //   - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the
+      // iOS networking stack.
+      if (userAgent.Contains("CPU iPhone OS 12")
+          || userAgent.Contains("iPad; CPU OS 12"))
+      {
+        return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack.
+      // This includes:
+      //   - Safari on Mac OS X.
+      // This does not include:
+      //   - Chrome on Mac OS X
+      // because they do not use the Mac OS networking stack.
+      if (userAgent.Contains("Safari")
+          && userAgent.Contains("Macintosh; Intel Mac OS X 10_14")
+          && userAgent.Contains("Version/"))
+      {
+        return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None
+      // and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions,
+      // but pre-Chromium Edge does not require SameSite=None.
+      if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6") || userAgent.Contains("Chrome/8"))
+      {
+        return true;
+      }
+
+      return false;
+    }
+  }
+}

--- a/generators/app/templates/src/FOOBAR/Startup/Startup.cs
+++ b/generators/app/templates/src/FOOBAR/Startup/Startup.cs
@@ -11,6 +11,8 @@ using Digipolis.ApplicationServices;
 using Digipolis.Correlation;
 using Digipolis.Authentication.OAuth;
 using Digipolis.Authentication.OAuth.Options;
+using FOOBAR.Shared.Extensions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 
@@ -77,9 +79,18 @@ namespace FOOBAR
             services.AddHelperServices();
             services.AddProgressiveWebApp();
 
-			      //Global error handling in the BFF adds chunked encoding errors with the passthrough
-			      //please keep that in mind if you are going to define a BFF API.
+            //Global error handling in the BFF adds chunked encoding errors with the passthrough
+            //please keep that in mind if you are going to define a BFF API.
             //services.AddGlobalErrorHandling<ApiExceptionMapper>();
+
+            services.ConfigureNonBreakingSameSiteCookies();
+
+            services.ConfigureApplicationCookie(options =>
+            {
+              options.Cookie.IsEssential = true;
+              // we need to disable to allow iframe for authorize requests
+              options.Cookie.SameSite = (SameSiteMode)(-1);
+            });
         }
 
         //This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Deze commit fixt het probleem van de samesite cookies in chrome dat voorkomt sinds de recente uitrol van Chrome.
Digipolis OAuth geeft in de logging volgende error:
` '.AspNetCore.Correlation.DigipolisOAuth.T8zSUPlzT98qb8Zu62VkrDX9snCQAvqcnvTmrM3E3Yc' cookie not found.`

Hierdoor kan de OAuthCallback niet correct verwerkt worden en krijgt de gebruiker een 500 internal server error.

https://blog.chromium.org/2019/10/developers-get-ready-for-new.html?m=1
https://www.thinktecture.com/en/identity/samesite/prepare-your-identityserver/